### PR TITLE
chore: declare types in package.json conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "import": "./src/index.js",
-      "require": "./lib/index.cjs"
+      "require": "./lib/index.cjs",
+      "types": "./types/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Fixes importing this package in TypeScript. Before, it expected the types to live next to the CJS/ESM files mentioned in `exports`. However, the types live in a separate directory.

With this change, [TypeScript will use this new explicit "types" condition](https://www.typescriptlang.org/docs/handbook/modules/reference.html#example-explicit-types-condition) to resolve types correctly.